### PR TITLE
Fixed build errors.

### DIFF
--- a/aeson-schema.cabal
+++ b/aeson-schema.cabal
@@ -28,7 +28,7 @@ library
                        Data.Aeson.TH.Lift
   extensions:          OverloadedStrings
   build-depends:       base > 4 && < 5,
-                       aeson >= 0.6.0.2,
+                       aeson >= 0.6.0.2 && < 0.7,
                        vector >= 0.7.1,
                        text >= 0.11.1.0,
                        regex-pcre >= 0.94.4,

--- a/src/Data/Aeson/Schema/CodeGen.hs
+++ b/src/Data/Aeson/Schema/CodeGen.hs
@@ -418,7 +418,7 @@ generateArray name schema = case schemaItems schema of
                -> CodeGenM SchemaTypes (TypeQ, ExpQ, ExpQ)
     tupleArray items additionalItems = return (tupleType, code $ additionalCheckers ++ [noBindS tupleParser], tupleTo)
       where
-        items' = flip map (zip [0..] items) $ \(i, (itemType, itemParser, itemTo)) ->
+        items' = flip map (zip [0::Int ..] items) $ \(i, (itemType, itemParser, itemTo)) ->
           let simpleParser = [| $(itemParser) (V.unsafeIndex $(varE arr) i) |]
           in if i < schemaMinItems schema
              then (itemType, simpleParser, [| return . $itemTo |])


### PR DESCRIPTION
I encountered two problems while building aeson-schema. The first one was that it uses Data.Attoparsec.Number, which is deprecated. I've quick-and-dirty fixed it by requiring aeson < 0.7 in the cabal file. The second problem: GHC seems to have issues inferring the right type for i in CodeGen.hs, line 422. I fixed it by adding an explicit annotation.