### PR TITLE
Add support for custom options

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,2 +1,2 @@
-:set -XQuasiQuotes
-:m +Data.Aeson Data.Aeson.Schema
+:set -isrc -idist/build -idist/build/autogen -optP-include -optPdist/build/autogen/cabal_macros.h -itest
+:set -XOverloadedStrings -XQuasiQuotes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.0.0
+
+- Add Data.Aeson.Schema.CodeGenM.Options type which allows
+  customisation of codegen output
+
 # 0.3.0.7 - 2015-07-15
 
 - Bump upper bounds: Allow vector-0.11

--- a/aeson-schema.cabal
+++ b/aeson-schema.cabal
@@ -1,5 +1,5 @@
 name:                aeson-schema
-version:             0.3.0.7
+version:             0.4.0.0
 synopsis:            Haskell JSON schema validator and parser generator
 description:         This library provides validation of JSON values against schemata. Given a schema, it can also produce data types corresponding to the schema and a parser.
 homepage:            https://github.com/timjb/aeson-schema

--- a/src/Data/Aeson/Schema/CodeGen.hs
+++ b/src/Data/Aeson/Schema/CodeGen.hs
@@ -199,7 +199,7 @@ assertStmt :: ExpQ -> String -> StmtQ
 assertStmt expr err = noBindS [| unless $(expr) (fail err) |]
 
 assertValidates :: ExpQ -> ExpQ -> StmtQ
-assertValidates schema value = noBindS
+assertValidates schema value = noBindS $ ParensE <$>
   [| case validate $(varE $ mkName "graph") $schema $value of
        [] -> return ()
        es -> fail $ unlines es

--- a/src/Data/Aeson/Schema/CodeGen.hs
+++ b/src/Data/Aeson/Schema/CodeGen.hs
@@ -199,7 +199,7 @@ assertStmt :: ExpQ -> String -> StmtQ
 assertStmt expr err = noBindS [| unless $(expr) (fail err) |]
 
 assertValidates :: ExpQ -> ExpQ -> StmtQ
-assertValidates schema value = noBindS $ ParensE <$>
+assertValidates schema value = noBindS $ parensE
   [| case validate $(varE $ mkName "graph") $schema $value of
        [] -> return ()
        es -> fail $ unlines es
@@ -389,11 +389,14 @@ generateObject decName name schema = case (propertiesList, schemaAdditionalPrope
     checkAdditionalProperties _ (Choice1of2 True) = [| return () |]
     checkAdditionalProperties _ (Choice1of2 False) = [| fail "additional properties are not allowed" |]
     checkAdditionalProperties value (Choice2of2 sch) = doE [assertValidates (lift sch) value]
+    -- TODO Once https://ghc.haskell.org/trac/ghc/ticket/10734 is
+    -- fixed, use a ‘let’ again for matchingPatterns and
+    -- isAdditionalProperty
     checkPatternAndAdditionalProperties patterns additional = noBindS
       [| let items = HM.toList $(varE obj) in forM_ items $ \(pname, value) -> do
-           let matchingPatterns = filter (flip PCRE.match (unpack pname) . patternCompiled . fst) $(lift patterns)
+           matchingPatterns <- return (filter (flip PCRE.match (unpack pname) . patternCompiled . fst) $(lift patterns))
            forM_ matchingPatterns $ \(_, sch) -> $(doE [assertValidates [| sch |] [| value |]])
-           let isAdditionalProperty = null matchingPatterns && pname `notElem` $(lift $ map fst $ HM.toList $ schemaProperties schema)
+           isAdditionalProperty <- return (null matchingPatterns && pname `notElem` $(lift $ map fst $ HM.toList $ schemaProperties schema))
            when isAdditionalProperty $(checkAdditionalProperties [| value |] additional)
       |]
     additionalPropertiesAllowed (Choice1of2 True) = True

--- a/src/Data/Aeson/Schema/CodeGen.hs
+++ b/src/Data/Aeson/Schema/CodeGen.hs
@@ -76,7 +76,7 @@ generateModule modName g opts = fmap (first $ renderCode . map rewrite) $ genera
         imprts = map (\m -> "import " <> pack m) mods
         modDec = "module " <> modName <> " where"
     rewrite :: Declaration -> Declaration
-    rewrite (Declaration dec text) = Declaration (replaceHiddenModules $ cleanPatterns dec) text
+    rewrite (Declaration dec text) = Declaration (replaceHiddenModules (cleanPatterns dec) (_replaceModules opts)) text
     rewrite a = a
 
 -- | Generate a generalized representation of the code in a Haskell module
@@ -348,9 +348,10 @@ generateObject decName name schema = case (propertiesList, schemaAdditionalPrope
                  )
       conName <- maybe (qNewName $ firstUpper $ unpack name) return decName
       tcs <- _derivingTypeclasses <$> askOpts
+      rMods <- _replaceModules <$> askOpts
       recordDeclaration <- runQ $ genRecord conName
                                             (zip3 propertyNames
-                                                  (map (fmap replaceHiddenModules) propertyTypes)
+                                                  (map (fmap (`replaceHiddenModules` rMods)) propertyTypes)
                                                   (map (schemaDescription . snd) propertiesList))
                                             tcs
       let typ = conT conName

--- a/src/Data/Aeson/Schema/CodeGen.hs
+++ b/src/Data/Aeson/Schema/CodeGen.hs
@@ -353,7 +353,7 @@ generateObject decName name schema = case (propertiesList, schemaAdditionalPrope
                                             (zip3 propertyNames
                                                   (map (fmap (`replaceHiddenModules` rMods)) propertyTypes)
                                                   (map (schemaDescription . snd) propertiesList))
-                                            tcs
+                                            (map (`replaceHiddenModules` rMods) tcs)
       let typ = conT conName
       let parser = foldl (\oparser propertyParser -> [| $oparser <*> $propertyParser |]) [| pure $(conE conName) |] propertyParsers
       fromJSONInst <- runQ $ instanceD (cxt []) (conT ''FromJSON `appT` typ)

--- a/src/Data/Aeson/Schema/CodeGenM.hs
+++ b/src/Data/Aeson/Schema/CodeGenM.hs
@@ -73,7 +73,7 @@ newtype CodeGenM s a = CodeGenM
 -- | Extra options used for the codegen
 data Options = Options
  { _extraModules :: [String]
-  -- ^ Needed modules that are not found by "getUsedModules".
+  -- ^ Needed modules that are not found by 'getUsedModules'.
  , _derivingTypeclasses :: [Name]
   -- ^ Classes to put in the @deriving@ clause
  , _replaceModules :: M.Map String String

--- a/src/Data/Aeson/Schema/CodeGenM.hs
+++ b/src/Data/Aeson/Schema/CodeGenM.hs
@@ -91,6 +91,18 @@ data Options = Options
   -- aren't checked for validity.
   --
   -- @'_ghcOptsPragmas' = [ "-fno-warn-name-shadowing" ]@
+ , _extraInstances :: Name -> [DecQ]
+  -- ^ Supplied a 'Name' of the type in question (after mangling),
+  -- potentially generate an instance for the type. For example, to
+  -- generate an empty 'Enum' instance for every data type we make,
+  -- the user can supply something like
+  --
+  -- @
+  -- _extraInstances = \n -> return $
+  --   instanceD (cxt []) (conT ''Enum `appT` conT n) []
+  -- @
+  --
+  -- and to generate no instances, simply use @'const' []@.
  }
 
 defaultOptions :: Options
@@ -118,6 +130,7 @@ defaultOptions = Options
        ]
   , _languageExtensions = []
   , _ghcOptsPragmas = []
+  , _extraInstances = const []
   }
 
 askOpts :: CodeGenM s Options

--- a/src/Data/Aeson/Schema/CodeGenM.hs
+++ b/src/Data/Aeson/Schema/CodeGenM.hs
@@ -127,6 +127,7 @@ defaultOptions = Options
          -- Due to mistake in base 4.8.{0,1} releases
        , ("Data.OldList", "Prelude")
        , ("Data.Typeable.Internal", "Data.Typeable")
+       , ("Data.Binary.Class", "Data.Binary")
        ]
   , _languageExtensions = []
   , _ghcOptsPragmas = []

--- a/src/Data/Aeson/Schema/CodeGenM.hs
+++ b/src/Data/Aeson/Schema/CodeGenM.hs
@@ -81,6 +81,16 @@ data Options = Options
   -- when references to them are found. Useful for example when the
   -- codegen is hitting a hidden module that's not already gotten rid
   -- of in 'Data.Aeson.Schema.Helpers.replaceHiddenModules'.
+ , _languageExtensions :: [Text]
+  -- ^ List of @LANGUAGE@ extensions to enable in the module. Note that
+  -- these aren't checked for validity.
+  --
+  -- @'_languageExtensions' = [ "LambdaCase" ]@
+ , _ghcOptsPragmas :: [Text]
+  -- ^ List of @OPTIONS_GHC@ to turn on in the module. Note that these
+  -- aren't checked for validity.
+  --
+  -- @'_ghcOptsPragmas' = [ "-fno-warn-name-shadowing" ]@
  }
 
 defaultOptions :: Options
@@ -106,6 +116,8 @@ defaultOptions = Options
        , ("Data.OldList", "Prelude")
        , ("Data.Typeable.Internal", "Data.Typeable")
        ]
+  , _languageExtensions = []
+  , _ghcOptsPragmas = []
   }
 
 askOpts :: CodeGenM s Options

--- a/src/Data/Aeson/Schema/Helpers.hs
+++ b/src/Data/Aeson/Schema/Helpers.hs
@@ -88,6 +88,10 @@ replaceHiddenModules = everywhere $ mkT replaceModule
       , ("GHC.Real", "Prelude")
       , ("Data.Text.Internal", "Data.Text")
       , ("Data.Map.Base", "Data.Map")
+        -- Due to mistake in base 4.8.{0,1} releases
+      , ("Data.OldList", "Prelude")
+      , ("Data.Typeable.Internal", "Data.Typeable")
+      ,
       ]
     replaceModule :: Name -> Name
     replaceModule n = case nameModule n of


### PR DESCRIPTION
This PR adds an `Option` data type. This allows the user to specify extra instances, pragmas, derivings, module replacements and imports.

It also improves the produced output: for our schemas, this program output invalid Haskell syntax: one issue was with `case` in `do` blocks and another was with `let` in `do` blocks. Both cases worked around now.

I make changes to types of the main entry points, `generate` and `generateModules` but if we really wanted to keep somewhat of a backwards compatibility, it's easy to simply add `generateOpt` and `generateModulesOpt` functions and define `generate` and `generateModules` in terms of them, simply supplying `defaultOptions`.

It'd be great if this could be release on Hackage soon. For us it means we no longer have to edit the generated modules by hand to make them work.

Thanks
